### PR TITLE
Optimize token embedding

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,7 @@ class ProjectConfig(BaseSettings):
     index_columns: str = "idx"
     input_column: str = "input"
     entries_column: str = "pickled_object"
+    device: str = "cpu"
 
 
 @lru_cache

--- a/src/utils/models_utils.py
+++ b/src/utils/models_utils.py
@@ -5,8 +5,28 @@ import torch
 import numpy as np
 from transformers import BertTokenizer, BertModel
 
+from src.config import config
+
 BERT_VECTOR_SIZE: Final[int] = 768
 BERT_PRETRAINED_NAME: Final[str] = "bert-base-uncased"
+
+# Cached tokenizer and model loaded once per process
+_GLOBAL_TOKENIZER: BertTokenizer | None = None
+_GLOBAL_MODEL: BertModel | None = None
+_GLOBAL_DEVICE: str | None = None
+
+
+def _ensure_global_model() -> tuple[BertTokenizer, BertModel]:
+    """Return a tokenizer and model placed on the configured device."""
+    global _GLOBAL_TOKENIZER, _GLOBAL_MODEL, _GLOBAL_DEVICE
+    device = config().device
+    if _GLOBAL_TOKENIZER is None or _GLOBAL_MODEL is None or _GLOBAL_DEVICE != device:
+        _GLOBAL_TOKENIZER = get_bert_tokenizer(config().bert_pretrained_name)
+        _GLOBAL_MODEL = get_bert_model(config().bert_pretrained_name)
+        _GLOBAL_MODEL.to(device)
+        _GLOBAL_MODEL.eval()
+        _GLOBAL_DEVICE = device
+    return _GLOBAL_TOKENIZER, _GLOBAL_MODEL
 
 
 @lru_cache
@@ -18,34 +38,42 @@ def get_bert_tokenizer(pretrained_model_name: str) -> BertTokenizer:
 def get_bert_model(pretrained_model_name: str) -> BertModel:
     return BertModel.from_pretrained(pretrained_model_name, output_hidden_states=True)
 
-def get_bert_vec(token: str, sentence: str) -> np.ndarray:
-    # 1. Load the BERT tokenizer and model.
-    tokenizer = get_bert_tokenizer(BERT_PRETRAINED_NAME)
-    model = get_bert_model(BERT_PRETRAINED_NAME)
 
-    # 2. Convert the sentence to tokens as PyTorch tensors.
-    inputs = tokenizer(sentence, return_tensors="pt")
+def get_bert_sentence_vectors(sentence: str) -> np.ndarray:
+    """Return vectors for all tokens in the given sentence."""
+    # 1. Retrieve the global tokenizer and model already loaded on the
+    #    configured device (CPU by default).
+    tokenizer, model = _ensure_global_model()
+    device = config().device
 
-    # 3. Run the sentence through the BERT model without back-propagation.
+    # 2. Tokenize the whole sentence and move the tensors to the device.
+    inputs = tokenizer(sentence, return_tensors="pt").to(device)
+
+    # 3. Run the sentence through BERT without computing gradients.
     with torch.no_grad():
         outputs = model(**inputs)
 
-    # 4. Since BERT doesn't have an output layer, the last hidden layer is our output.
-    output = outputs.last_hidden_state
+    # 4. Grab the last hidden state for every token, excluding the special
+    #    [CLS] and [SEP] tokens added by BERT.
+    hidden_states = outputs.last_hidden_state.squeeze(0)
+    return hidden_states[1:-1].cpu().numpy()
 
-    # 5. We want to find the specific vector created for our token, so we first need to re-tokenize the sentence
-    # to split it using BERT's splitting rules.
-    sentence_tokens = tokenizer.tokenize(sentence)
-    # 6. Then We convert the tokens to their IDs.
-    sentence_token_ids = tokenizer.convert_tokens_to_ids(sentence_tokens)
-    # 7. Retrieve the ID of our specific token.
-    token_id = tokenizer.convert_tokens_to_ids(token)
 
-    # 8. We try to extract the token index from the sentence (if it exists in the sentence).
+def get_bert_vec(token: str, sentence: str) -> np.ndarray:
+    """Return the BERT vector of a specific token within a sentence."""
+    # 1. Load the tokenizer (the model is already cached in
+    #    ``get_bert_sentence_vectors``).
+    tokenizer, _ = _ensure_global_model()
+
+    # 2. Compute the embeddings for the entire sentence just once.
+    sentence_vectors = get_bert_sentence_vectors(sentence)
+
+    # 3. Tokenize again so we can locate the index of the desired token.
+    tokens = tokenizer.tokenize(sentence)
     try:
-        token_index = sentence_token_ids.index(token_id)
+        token_index = tokens.index(token)
     except ValueError:
         raise ValueError(f"Token '{token}' not found in the sentence '{sentence}'")
 
-    # 9. Extract the specific embedding for our token.
-    return output[0, token_index, :].numpy()
+    # 4. Return the vector of the specified token.
+    return sentence_vectors[token_index]

--- a/src/utils/parsing_utils.py
+++ b/src/utils/parsing_utils.py
@@ -1,24 +1,15 @@
-import logging
 from collections import Counter
-from typing import TYPE_CHECKING
 
 import numpy as np
 
 from src.config import config
 from src.data_models import TokenEntry
-from src.utils.models_utils import get_bert_tokenizer, get_bert_vec
+from src.utils.models_utils import get_bert_tokenizer, get_bert_sentence_vectors
 
-# if TYPE_CHECKING:
-#     from src.bert_2_vec_model import Bert2VecModel
 
 def tokenize_sentence(sentence: str) -> list[str]:
     tokenizer = get_bert_tokenizer(config().bert_pretrained_name)
     return tokenizer.tokenize(sentence)
-
-
-# def unite_tokens(tokens: list[str], environment bert2vec_model: Bert2VecModel) -> tuple[str, np.array]:
-#     bert2vec_entries = [ver]
-#
 
 
 def get_bow(tokens: list, idx: int, size: int = 5):
@@ -33,7 +24,8 @@ def unite_tokens(token_list: list[tuple[str, np.ndarray]]) -> tuple[str, np.ndar
 
 def unite_sentence_tokens(sentence: str, bert2vec_model, bow_size: int = 5) -> list[TokenEntry]:
     tokens = tokenize_sentence(sentence)
-    # tokens = ['his', 'behavior', 'during', 'the', 'un', '##pro', '##fe', '##ssion', '##al', 'meeting', 'up', '##set', 'both', 'clients', 'and', 'colleagues', '.']
+    bert_vectors = get_bert_sentence_vectors(sentence)
+
     idx = len(tokens) - 1
     buffer: list[tuple[str, np.ndarray]] = []
     entries: list[TokenEntry] = []
@@ -41,7 +33,7 @@ def unite_sentence_tokens(sentence: str, bert2vec_model, bow_size: int = 5) -> l
         token = tokens[idx]
         bow = get_bow(tokens=tokens, idx=idx, size=bow_size)
         entry = bert2vec_model.get_entry_by_bow(token=token, bow=bow)
-        vec = entry.vec if entry else get_bert_vec(token=token, sentence=sentence)
+        vec = entry.vec if entry else bert_vectors[idx]
         buffer.append((token, vec))
         if not tokens[idx].startswith("##"):
             if len(buffer) > 1:
@@ -49,7 +41,7 @@ def unite_sentence_tokens(sentence: str, bert2vec_model, bow_size: int = 5) -> l
                 token, vec = unite_tokens(buffer[::-1])
 
             # The list of tokens after merging only the current tokens
-            merged_tokens = tokens[:idx] + [token] + tokens[idx + len(buffer):]
+            merged_tokens = tokens[:idx] + [token] + tokens[idx + len(buffer) :]
             bow_b2v = get_bow(tokens=merged_tokens, idx=idx, size=bow_size)
 
             entry = TokenEntry(bow_b2v=dict(Counter(bow_b2v)), token=token, vec=vec)


### PR DESCRIPTION
## Summary
- cache BERT tokenizer/model per process and keep them on CPU
- compute all BERT vectors once per sentence in `unite_sentence_tokens`
- load device setting from project config

## Testing
- `pytest -q`
- `black --check .` *(fails: would reformat 13 files)*

------
https://chatgpt.com/codex/tasks/task_e_6884f96a073c832686ca7a8f4812cb04