### PR TITLE
feat: support compact model in disambiguation

### DIFF
--- a/.idea/data_source_mapping.xml
+++ b/.idea/data_source_mapping.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourcePerFileMappings">
+    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/225f18b7-99e4-44fd-a4e9-4e89d4d1bc6a/console.sql" value="225f18b7-99e4-44fd-a4e9-4e89d4d1bc6a" />
     <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/ecee58c0-395e-4edb-be4c-f24d0943fcbc/console_2.sql" value="ecee58c0-395e-4edb-be4c-f24d0943fcbc" />
   </component>
 </project>


### PR DESCRIPTION
## Summary
- allow `disambiguate_sentence_tokens` to accept either `Bert2VecModel` or `CompactBert2VecModel`
- dynamically fetch token entries when using compact model
- add `compact` flag to `disambiguate_dataset` to load compact models in workers

## Testing
- `python -m black src/main.py src/utils/parsing_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd1846282883268843225890da9cfe